### PR TITLE
Fixed the routes for the info and multi_message logs

### DIFF
--- a/cmd/sonic-pi-logs/main.go
+++ b/cmd/sonic-pi-logs/main.go
@@ -10,10 +10,10 @@ import (
 func main() {
 	server := &osc.Server{Addr: "localhost:4558"}
 
-	try(server.Handle("/info", func(msg *osc.Message) {
+	try(server.Handle("/log/info", func(msg *osc.Message) {
 		fmt.Print(log.Info(msg.Arguments))
 	}))
-	try(server.Handle("/multi_message", func(msg *osc.Message) {
+	try(server.Handle("/log/multi_message", func(msg *osc.Message) {
 		fmt.Print(log.MultiMessage(msg.Arguments))
 	}))
 	try(server.Handle("/syntax_error", func(msg *osc.Message) {


### PR DESCRIPTION
Hi,

The route paths were recently changed from `/info` and `/multi_message` to `/log/info` and `/log/multi_message`: https://github.com/samaaron/sonic-pi/commit/2af15201d177c8b0e88c08dc0e19138efa046d9e.

Tested with Sonic Pi 2.12.0 and it seems to work better now.