### PR TITLE
Format all the files with cargo fmt

### DIFF
--- a/src/log_packet.rs
+++ b/src/log_packet.rs
@@ -39,9 +39,9 @@ fn format_string_arg<F>(msg: &OscMessage, index: usize, fmt: F) -> Option<String
         .as_ref()
         .and_then(|args| args.get(index))
         .and_then(|e| match *e {
-            OscType::String(ref string) => Some(fmt(string)),
-            _ => None,
-        })
+                      OscType::String(ref string) => Some(fmt(string)),
+                      _ => None,
+                  })
 }
 
 fn format_multi_message(msg: OscMessage) -> Option<String> {
@@ -59,9 +59,9 @@ impl Message {
         match (msg_type, info) {
             (&OscType::Int(i), &OscType::String(ref s)) => {
                 Some(Message {
-                    msg_type: i,
-                    info: s.to_string(),
-                })
+                         msg_type: i,
+                         info: s.to_string(),
+                     })
             }
             _ => None,
         }
@@ -165,9 +165,9 @@ mod tests {
         let runtime = OscType::String("1293.1".to_string());
         let num_msgs = OscType::Int(0);
         let msg = OscPacket::Message(OscMessage {
-            addr: "/multi_message".to_string(),
-            args: Some(vec![job_id, thread_name, runtime, num_msgs]),
-        });
+                                         addr: "/multi_message".to_string(),
+                                         args: Some(vec![job_id, thread_name, runtime, num_msgs]),
+                                     });
         let expected = "[Run 2, Time 1293.1]\n".to_string();
         let output = to_log_string(msg);
         println!("expected:{}", expected);
@@ -182,9 +182,9 @@ mod tests {
         let runtime = OscType::String("1293.1".to_string());
         let num_msgs = OscType::Int(0);
         let msg = OscPacket::Message(OscMessage {
-            addr: "/log/multi_message".to_string(),
-            args: Some(vec![job_id, thread_name, runtime, num_msgs]),
-        });
+                                         addr: "/log/multi_message".to_string(),
+                                         args: Some(vec![job_id, thread_name, runtime, num_msgs]),
+                                     });
         let expected = "[Run 2, Time 1293.1]\n".to_string();
         let output = to_log_string(msg);
         println!("expected:{}", expected);
@@ -201,14 +201,19 @@ mod tests {
         let msg1_type = OscType::Int(0);
         let msg1_info = OscType::String("synth :beep".to_string());
         let msg = OscPacket::Message(OscMessage {
-            addr: "/multi_message".to_string(),
-            args: Some(vec![job_id, thread_name, runtime, num_msgs, msg1_type, msg1_info]),
-        });
+                                         addr: "/multi_message".to_string(),
+                                         args: Some(vec![job_id,
+                                                         thread_name,
+                                                         runtime,
+                                                         num_msgs,
+                                                         msg1_type,
+                                                         msg1_info]),
+                                     });
         let expected = format!(r#"[Run 2, Time 1293.1]
  └ {}
 "#,
                                Purple.paint("synth :beep"))
-            .to_string();
+                .to_string();
         let output = to_log_string(msg);
         println!("expected:{}", expected);
         println!("actual:{}", output);
@@ -226,23 +231,23 @@ mod tests {
         let msg2_type = OscType::Int(11);
         let msg2_info = OscType::String("synth :boop".to_string());
         let msg = OscPacket::Message(OscMessage {
-            addr: "/multi_message".to_string(),
-            args: Some(vec![job_id,
-                            thread_name,
-                            runtime,
-                            num_msgs,
-                            msg1_type,
-                            msg1_info,
-                            msg2_type,
-                            msg2_info]),
-        });
+                                         addr: "/multi_message".to_string(),
+                                         args: Some(vec![job_id,
+                                                         thread_name,
+                                                         runtime,
+                                                         num_msgs,
+                                                         msg1_type,
+                                                         msg1_info,
+                                                         msg2_type,
+                                                         msg2_info]),
+                                     });
         let expected = format!(r#"[Run 2, Time 1293.1]
  ├ {}
  └ {}
 "#,
                                Purple.paint("synth :beep"),
                                Green.paint("synth :boop"))
-            .to_string();
+                .to_string();
         let output = to_log_string(msg);
         println!("expected:{}", expected);
         println!("actual:{}", output);
@@ -252,18 +257,20 @@ mod tests {
     #[test]
     fn info_test() {
         let msg = OscPacket::Message(OscMessage {
-            addr: "/info".to_string(),
-            args: Some(vec![OscType::Int(1), OscType::String("Hello!".to_string())]),
-        });
+                                         addr: "/info".to_string(),
+                                         args: Some(vec![OscType::Int(1),
+                                                         OscType::String("Hello!".to_string())]),
+                                     });
         assert_eq!("=> Hello!\n", to_log_string(msg));
     }
 
     #[test]
     fn log_info_test() {
         let msg = OscPacket::Message(OscMessage {
-            addr: "/log/info".to_string(),
-            args: Some(vec![OscType::Int(1), OscType::String("Hello!".to_string())]),
-        });
+                                         addr: "/log/info".to_string(),
+                                         args: Some(vec![OscType::Int(1),
+                                                         OscType::String("Hello!".to_string())]),
+                                     });
         assert_eq!("=> Hello!\n", to_log_string(msg));
     }
 
@@ -272,17 +279,17 @@ mod tests {
         let error_txt = r#"[]
 Thread death +--&gt; :live_loop_no_sleep_loop
  Live loop :no_sleep_loop did not sleep!"#
-            .to_string();
+                .to_string();
         let backtrace = r#"lang/thing.rb:3442:in `block in out_thread&#39;
 lang/core.rb:2863:in `block in in_thread&#39;"#
-            .to_string();
+                .to_string();
         let msg = OscPacket::Message(OscMessage {
-            addr: "/error".to_string(),
-            args: Some(vec![OscType::Int(24),
-                            OscType::String(error_txt),
-                            OscType::String(backtrace),
-                            OscType::Int(1)]),
-        });
+                                         addr: "/error".to_string(),
+                                         args: Some(vec![OscType::Int(24),
+                                                         OscType::String(error_txt),
+                                                         OscType::String(backtrace),
+                                                         OscType::Int(1)]),
+                                     });
         let expected = r#"Runtime Error: []
 Thread death +--&gt; :live_loop_no_sleep_loop
  Live loop :no_sleep_loop did not sleep!
@@ -295,9 +302,11 @@ Thread death +--&gt; :live_loop_no_sleep_loop
     fn syntax_error_test() {
         let error_txt = "a.rb:1: syntax error, unexpected end-of-input".to_string();
         let msg = OscPacket::Message(OscMessage {
-            addr: "/syntax_error".to_string(),
-            args: Some(vec![OscType::Int(24), OscType::String(error_txt), OscType::Int(1)]),
-        });
+                                         addr: "/syntax_error".to_string(),
+                                         args: Some(vec![OscType::Int(24),
+                                                         OscType::String(error_txt),
+                                                         OscType::Int(1)]),
+                                     });
         let expected = "Syntax Error: a.rb:1: syntax error, unexpected end-of-input\n\n"
             .to_string();
         assert_eq!(expected, to_log_string(msg));

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,9 +17,9 @@ fn main() {
     let eval = SubCommand::with_name("eval")
         .about("Takes a string of Sonic Pi code and sends it to the server")
         .arg(Arg::with_name("CODE")
-            .help("A string of Sonic Pi code")
-            .required(true)
-            .index(1));
+                 .help("A string of Sonic Pi code")
+                 .required(true)
+                 .index(1));
 
     let eval_stdin = SubCommand::with_name("eval-stdin")
         .about("Reads Sonic Pi code from stdin and sends it to the server");
@@ -27,20 +27,21 @@ fn main() {
     let eval_file = SubCommand::with_name("eval-file")
         .about("Reads Sonic Pi code from a file and sends it to the server")
         .arg(Arg::with_name("PATH")
-            .help("Path to the file of Sonic Pi code")
-            .required(true)
-            .index(1));
+                 .help("Path to the file of Sonic Pi code")
+                 .required(true)
+                 .index(1));
 
-    let start_server = SubCommand::with_name("start-server")
-        .about("Find and start the Sonic Pi server");
+    let start_server =
+        SubCommand::with_name("start-server").about("Find and start the Sonic Pi server");
 
-    let stop = SubCommand::with_name("stop")
-        .about("Stops all currently playing music on the server");
+    let stop =
+        SubCommand::with_name("stop").about("Stops all currently playing music on the server");
 
-    let logs = SubCommand::with_name("logs")
-        .about("Print log events emitted by the Sonic Pi server");
+    let logs =
+        SubCommand::with_name("logs").about("Print log events emitted by the Sonic Pi server");
 
-    let matches = cli_app.subcommand(stop)
+    let matches = cli_app
+        .subcommand(stop)
         .subcommand(check)
         .subcommand(logs)
         .subcommand(eval)
@@ -62,7 +63,8 @@ fn main() {
 }
 
 fn do_eval_file(matches: &clap::ArgMatches) {
-    let path = matches.subcommand_matches("eval-file")
+    let path = matches
+        .subcommand_matches("eval-file")
         .unwrap()
         .value_of("PATH")
         .unwrap()
@@ -71,7 +73,8 @@ fn do_eval_file(matches: &clap::ArgMatches) {
 }
 
 fn do_eval(matches: &clap::ArgMatches) {
-    let code = matches.subcommand_matches("eval")
+    let code = matches
+        .subcommand_matches("eval")
         .unwrap()
         .value_of("CODE")
         .unwrap()

--- a/src/server.rs
+++ b/src/server.rs
@@ -26,9 +26,9 @@ pub fn run_code(source: String) {
     let osc_source = OscType::String(source);
 
     let msg = &OscPacket::Message(OscMessage {
-        addr: "/run-code".to_string(),
-        args: Some(vec![client_name, osc_source]),
-    });
+                                      addr: "/run-code".to_string(),
+                                      args: Some(vec![client_name, osc_source]),
+                                  });
     let msg_buf = encoder::encode(msg).unwrap();
     send(&msg_buf);
 }
@@ -40,9 +40,9 @@ pub fn stop_all_jobs() {
     let client_name = OscType::String("SONIC_PI_TOOL".to_string());
 
     let msg = &OscPacket::Message(OscMessage {
-        addr: "/stop-all-jobs".to_string(),
-        args: Some(vec![client_name]),
-    });
+                                      addr: "/stop-all-jobs".to_string(),
+                                      args: Some(vec![client_name]),
+                                  });
     let msg_buf = encoder::encode(msg).unwrap();
     send(&msg_buf);
 }


### PR DESCRIPTION
The last PR failed because of the CI build running `cargo fmt`.

It would be good to reformat all the source files at least once so the CI doesn't complain about the style in the future.
I have to say that the default format from `cargo fmt` looks a bit odd in some situations. But I guess it's just following Rust guidelines?