### PR TITLE
start_server() patch to check additional path

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,8 @@ pub fn logs() {
 ///
 pub fn start_server() {
     let paths = ["/Applications/Sonic Pi.app/server/bin/sonic-pi-server.rb",
-                 "./app/server/bin/sonic-pi-server.rb", "/usr/lib/sonic-pi/server/bin/sonic-pi-server.rb"];
+                 "./app/server/bin/sonic-pi-server.rb",
+                 "/usr/lib/sonic-pi/server/bin/sonic-pi-server.rb"];
 
     match paths.iter().find(|&&p| Path::new(p).exists()) {
         Some(p) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ pub fn logs() {
 ///
 pub fn start_server() {
     let paths = ["/Applications/Sonic Pi.app/server/bin/sonic-pi-server.rb",
-                 "./app/server/bin/sonic-pi-server.rb"];
+                 "./app/server/bin/sonic-pi-server.rb", "/usr/lib/sonic-pi/server/bin/sonic-pi-server.rb"];
 
     match paths.iter().find(|&&p| Path::new(p).exists()) {
         Some(p) => {


### PR DESCRIPTION
This is a small addition to the start_server() function in lib.rs to check the install directory for Sonic Pi on Debian (/usr/lib/sonic-pi/server/bin/sonic-pi-server.rb). I can not confirm if this will also work on other linux distributions. 