### PR TITLE
Added default location on Raspbian.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,7 @@ pub fn logs() {
 pub fn start_server() {
     let paths = ["/Applications/Sonic Pi.app/server/bin/sonic-pi-server.rb",
                  "./app/server/bin/sonic-pi-server.rb",
+                 "/opt/sonic-pi/app/server/bin/sonic-pi-server.rb",
                  "/usr/lib/sonic-pi/server/bin/sonic-pi-server.rb"];
 
     match paths.iter().find(|&&p| Path::new(p).exists()) {


### PR DESCRIPTION
sonic-pi-tool can't find the server executable on a default sonic-pi installation on the raspberry pi. This branch adds the absolute file path to sonic-pi-server.rb in Raspbian.