### PR TITLE
record command to save the audio output to a local file

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Other installation methods will (hopefully) come at a later date.
 - [stop](#stop)
 - [logs](#logs)
 - [start-server](#start-server)
+- [record](#record)
 
 ### `check`
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,16 @@ sonic-pi-tool start-server
 # ...
 ```
 
+### `record`
+
+Record the audio output of a Sonic Pi session to a local file.
+Stop and save the recording when the <Enter> key is pressed.
+
+```sh
+sonic-pi-tool record /tmp/output.wav
+# Recording started, saving to /tmp/output.wav.
+# Press Enter to stop the recording...
+```
 
 ## Other tools
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,3 +109,17 @@ pub fn start_server() {
         }
     };
 }
+
+/// Record the audio output of a Sonic Pi session to a local file.
+/// Stop and save the recording when the <Enter> key is pressed.
+///
+pub fn record(path: &str) {
+    server::start_recording();
+    let mut input = String::new();
+    match io::stdin().read_line(&mut input) {
+        Ok(_) => {
+            server::stop_and_save_recording(path.to_string());
+        }
+        Err(error) => println!("error: {}", error),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,11 +115,16 @@ pub fn start_server() {
 ///
 pub fn record(path: &str) {
     server::start_recording();
+    println!("Recording started, saving to {}", path);
+    println!("Press Enter to stop the recording...");
     let mut input = String::new();
     match io::stdin().read_line(&mut input) {
         Ok(_) => {
             server::stop_and_save_recording(path.to_string());
         }
-        Err(error) => println!("error: {}", error),
+        Err(error) => {
+            println!("error: {}", error);
+            server::stop_and_save_recording(path.to_string());
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,15 @@ fn main() {
     let logs =
         SubCommand::with_name("logs").about("Print log events emitted by the Sonic Pi server");
 
+    let record = SubCommand::with_name("record")
+        .about("Record the audio output of a Sonic Pi session")
+        .arg(
+            Arg::with_name("PATH")
+                .help("Absolute path to the output file")
+                .required(true)
+                .index(1),
+        );
+
     let matches = cli_app
         .subcommand(stop)
         .subcommand(check)
@@ -54,6 +63,7 @@ fn main() {
         .subcommand(eval_stdin)
         .subcommand(eval_file)
         .subcommand(start_server)
+        .subcommand(record)
         .get_matches();
 
     match matches.subcommand_name() {
@@ -64,6 +74,7 @@ fn main() {
         Some("eval-stdin") => lib::eval_stdin(),
         Some("start-server") => lib::start_server(),
         Some("logs") => lib::logs(),
+        Some("record") => do_record(&matches),
         _ => panic!("This should be unreachable."),
     }
 }
@@ -86,4 +97,14 @@ fn do_eval(matches: &clap::ArgMatches) {
         .unwrap()
         .to_string();
     lib::eval(code);
+}
+
+fn do_record(matches: &clap::ArgMatches) {
+    let path = matches
+        .subcommand_matches("record")
+        .unwrap()
+        .value_of("PATH")
+        .unwrap()
+        .to_string();
+    lib::record(&path);
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -68,6 +68,37 @@ pub fn follow_logs() -> Result<(), FollowLogError> {
     }
 }
 
+pub fn start_recording() {
+    let client_name = OscType::String("SONIC_PI_TOOL".to_string());
+
+    let msg = &OscPacket::Message(OscMessage {
+        addr: "/start-recording".to_string(),
+        args: Some(vec![client_name]),
+    });
+    let msg_buf = encoder::encode(msg).unwrap();
+    send(&msg_buf);
+}
+
+pub fn stop_and_save_recording(path: String) {
+    let stop = &OscPacket::Message(OscMessage {
+        addr: "/stop-recording".to_string(),
+        args: Some(vec![OscType::String("SONIC_PI_TOOL".to_string())]),
+    });
+    let stop_buf = encoder::encode(stop).unwrap();
+    send(&stop_buf);
+
+    let output_file = OscType::String(path);
+    let save = &OscPacket::Message(OscMessage {
+        addr: "/save-recording".to_string(),
+        args: Some(vec![
+            OscType::String("SONIC_PI_TOOL".to_string()),
+            output_file,
+        ]),
+    });
+    let save_buf = encoder::encode(save).unwrap();
+    send(&save_buf);
+}
+
 /// Send an OSC message to the Sonic Pi server, which is presumed to be
 /// listening on UDP port 4557.
 ///


### PR DESCRIPTION
Implemented a `record` command in a similar way as the existing commands:
- Start with: `sonic-pi-tool record /absolute/path/to/file.wav`
- Press Enter to stop (reads from stdin)

This is based on the discussion from #5, but **there is room for improvement**:
- Handle relative paths. If we use `sonic-pi-tool record ./test.wav` it should save to the current directory.
- Use Ctrl-C / Ctrl-D to stop the recording. Enter does the job for now but it might be better to handle signals properly.