### PR TITLE
Removed angle brackets around Enter in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ sonic-pi-tool start-server
 ### `record`
 
 Record the audio output of a Sonic Pi session to a local file.
-Stop and save the recording when the <Enter> key is pressed.
+Stop and save the recording when the Enter key is pressed.
 
 ```sh
 sonic-pi-tool record /tmp/output.wav


### PR DESCRIPTION
The word "Enter" is currently hidden because of the angle brackets.