### PR TITLE
Add support for Sonic Pi v3.1 on Mac

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,7 @@ pub fn logs() {
 pub fn start_server() {
     let mut paths = vec![
         String::from("/Applications/Sonic Pi.app/server/bin/sonic-pi-server.rb"),
+        String::from("/Applications/Sonic Pi.app/server/ruby/bin/sonic-pi-server.rb"),
         String::from("./app/server/bin/sonic-pi-server.rb"),
         String::from("/opt/sonic-pi/app/server/bin/sonic-pi-server.rb"),
         String::from("/usr/lib/sonic-pi/server/bin/sonic-pi-server.rb"),


### PR DESCRIPTION
When running the `start-server` command with the latest release of [`sonic-pi-tool`](https://github.com/lpil/sonic-pi-tool/commit/12b7ae87b8018f2ee90d770045770258f6d5b968) and the latest Sonic Pi v3.1, then `sonic-pi-tool` immediately exits with an error: 

```bash
$ sonic-pi-tool start-server
I couldn't find the Sonic Pi server executable :(
```

The location of the `server.rb` changed to `/Applications/Sonic Pi.app/server/ruby/bin/sonic-pi-server.rb` in Sonic Pi v3.1, and so this PR aims to add support for Sonic Pi v3.1 by adding this new location of the server script to the list of paths `sonic-pi-tool` looks for when trying to start the Sonic Pi server.

I'm completely new to Rust and `sonic-pi-tool` but from what I can see, this change should fix the problem and have no side-effects.

And while I'm here: Thank you soooo much for `sonic-pi-tool` and enabling me to retain my muscle memory while making beats 👍 😃 💯 