### PR TITLE
Fix compilation error with execv type inference

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ pub fn start_server() {
     match paths.iter().find(|p| Path::new(&p).exists()) {
         Some(p) => {
             let cmd = &CString::new(p.clone()).unwrap();
-            execv(cmd, &[]).unwrap_or_else(|_| panic!("Unable to start {}", *p))
+            execv::<CString>(cmd, &[]).unwrap_or_else(|_| panic!("Unable to start {}", *p))
         }
         None => {
             println!("I couldn't find the Sonic Pi server executable :(");


### PR DESCRIPTION
error[E0282]: type annotations needed
   --> src/lib.rs:111:13
    |
111 |             execv(cmd, &[]).unwrap_or_else(|_| panic!("Unable to start {}", *p))
    |             ^^^^^ cannot infer type of the type parameter `S` declared on the function `execv`